### PR TITLE
Update dependencies and offer to install tools as needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "static-analyser"
 version = "0.1.0"
 
 [build-dependencies]
-tango = "0.7"
+tango = "0.8"
 
 [dependencies]
 error-chain = "0.11"

--- a/Makefile
+++ b/Makefile
@@ -12,20 +12,20 @@ usage:
 
 open: build
 	cargo doc --open
-	$OPEN ./book/index.html
+	${OPEN} target/book/index.html
 
 build: build-crate build-docs
 
-build-crate:
-	tango
+build-crate: src/lib.rs
 	cargo build
 
 build-docs:
+	bash -c 'type mdbook' || ${MAKE} try-install target=mdbook
 	mdbook build
 
 clean:
-	cargo clean 
-	git clean -f -x -d 
+	cargo clean
+	git clean -f -x -d
 
 word-count:
 	-@ echo -e "lines words file"
@@ -33,5 +33,17 @@ word-count:
 	-@ wc --lines --words $$(find src/ -name "*.md")
 
 todo:
+	bash -c 'type rg' || ${MAKE} try-install target=ripgrep
 	rg 'TODO|FIXME' --iglob '*.md'
 
+src/lib.rs:
+	bash -c 'type tango' || ${MAKE} try-install target=tango
+	tango
+
+try-install:
+	test -n "${target}" || ( echo must supply target; exit 1 )
+	export ans=`bash -c 'read -p "Install ${target} with cargo (N/y)? " ans; \
+		ans=$${ans:-n}; echo $${ans:0:1} | tr "[:upper:]" "[:lower:]"'` && \
+		test "$$ans" = "y" && \
+			cargo install ${target} || \
+			exit 10


### PR DESCRIPTION
* Bump tango to 0.8 (needed for newer Rust?).
* Make the creation of src/lib.rs a dependency.
* Add try-install rule to ask if the user wants to install a dependency via cargo.
* Properly invoke ${OPEN} since otherwise it looks like you're trying to call PEN since Make would
  only consider $O as the variable.

Fixes #3